### PR TITLE
feat: add String() method to Command

### DIFF
--- a/command_string_test.go
+++ b/command_string_test.go
@@ -1,0 +1,170 @@
+// Copyright 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package zapscript_test
+
+import (
+	"testing"
+
+	"github.com/ZaparooProject/go-zapscript"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+)
+
+func TestCommandString(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		cmd  zapscript.Command
+		want string
+	}{
+		{
+			name: "name only",
+			cmd:  zapscript.Command{Name: "stop"},
+			want: "**stop",
+		},
+		{
+			name: "single arg",
+			cmd:  zapscript.Command{Name: "launch", Args: []string{"/games/snes/mario.sfc"}},
+			want: "**launch:/games/snes/mario.sfc",
+		},
+		{
+			name: "multiple args",
+			cmd:  zapscript.Command{Name: "greet", Args: []string{"hi", "there"}},
+			want: "**greet:hi,there",
+		},
+		{
+			name: "arg with comma needs quoting",
+			cmd:  zapscript.Command{Name: "say", Args: []string{"hello, world"}},
+			want: `**say:"hello, world"`,
+		},
+		{
+			name: "arg with colon needs quoting",
+			cmd:  zapscript.Command{Name: "say", Args: []string{"key:value"}},
+			want: `**say:"key:value"`,
+		},
+		{
+			name: "arg with newline re-escapes",
+			cmd:  zapscript.Command{Name: "echo", Args: []string{"hello\nworld"}},
+			want: `**echo:"hello^nworld"`,
+		},
+		{
+			name: "arg with tab re-escapes",
+			cmd:  zapscript.Command{Name: "echo", Args: []string{"one\ttwo"}},
+			want: `**echo:"one^ttwo"`,
+		},
+		{
+			name: "arg with caret re-escapes",
+			cmd:  zapscript.Command{Name: "echo", Args: []string{"2^3"}},
+			want: `**echo:"2^^3"`,
+		},
+		{
+			name: "with advanced args",
+			cmd: zapscript.Command{
+				Name:    "launch",
+				Args:    []string{"game.exe"},
+				AdvArgs: zapscript.NewAdvArgs(map[string]string{"platform": "win"}),
+			},
+			want: "**launch:game.exe?platform=win",
+		},
+		{
+			name: "advanced args only",
+			cmd: zapscript.Command{
+				Name:    "example",
+				AdvArgs: zapscript.NewAdvArgs(map[string]string{"debug": "true"}),
+			},
+			want: "**example?debug=true",
+		},
+		{
+			name: "input.keyboard macro",
+			cmd:  zapscript.Command{Name: "input.keyboard", Args: []string{"a", "b", "c"}},
+			want: "**input.keyboard:abc",
+		},
+		{
+			name: "input.keyboard with extensions",
+			cmd:  zapscript.Command{Name: "input.keyboard", Args: []string{"{f1}", "a", "{ctrl+q}"}},
+			want: "**input.keyboard:{f1}a{ctrl+q}",
+		},
+		{
+			name: "input.gamepad macro",
+			cmd:  zapscript.Command{Name: "input.gamepad", Args: []string{"^", "^", "V", "V", "<", ">"}},
+			want: "**input.gamepad:^^VV<>",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := tt.cmd.String()
+			if got != tt.want {
+				t.Errorf("Command.String() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCommandString_RoundTrip(t *testing.T) {
+	t.Parallel()
+
+	// Commands that should round-trip: parse → String() → parse → same Command
+	inputs := []string{
+		"**stop",
+		"**launch:/games/snes/mario.sfc",
+		"**greet:hi,there",
+		`**say:"hello, world"`,
+		"**launch:game.exe?platform=win",
+		"**input.keyboard:abc{f1}{enter}",
+		"**input.gamepad:^^VV<><>",
+		"**delay:500",
+		"**launch.random:SNES",
+		"**http.get:https://example.com/api",
+	}
+
+	for _, input := range inputs {
+		t.Run(input, func(t *testing.T) {
+			t.Parallel()
+
+			// Parse the original input
+			reader1 := zapscript.NewParser(input)
+			script1, err := reader1.ParseScript()
+			if err != nil {
+				t.Fatalf("first parse failed: %v", err)
+			}
+			if len(script1.Cmds) != 1 {
+				t.Fatalf("expected 1 command, got %d", len(script1.Cmds))
+			}
+
+			// Convert to string
+			str := script1.Cmds[0].String()
+
+			// Parse the string output
+			reader2 := zapscript.NewParser(str)
+			script2, err := reader2.ParseScript()
+			if err != nil {
+				t.Fatalf("second parse of %q failed: %v", str, err)
+			}
+			if len(script2.Cmds) != 1 {
+				t.Fatalf("expected 1 command from re-parse, got %d", len(script2.Cmds))
+			}
+
+			// Compare
+			if diff := cmp.Diff(script1.Cmds[0], script2.Cmds[0], cmpopts.IgnoreUnexported(zapscript.AdvArgs{})); diff != "" {
+				t.Errorf("round-trip mismatch (-original +reparsed):\n  input:    %s\n  string(): %s\n%s",
+					input, str, diff)
+			}
+		})
+	}
+}

--- a/command_string_test.go
+++ b/command_string_test.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/ZaparooProject/go-zapscript"
 	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 )
 
 func TestCommandString(t *testing.T) {
@@ -28,8 +27,8 @@ func TestCommandString(t *testing.T) {
 
 	tests := []struct {
 		name string
-		cmd  zapscript.Command
 		want string
+		cmd  zapscript.Command
 	}{
 		{
 			name: "name only",
@@ -81,6 +80,15 @@ func TestCommandString(t *testing.T) {
 			want: "**launch:game.exe?platform=win",
 		},
 		{
+			name: "advanced args sorted",
+			cmd: zapscript.Command{
+				Name:    "launch",
+				Args:    []string{"game.exe"},
+				AdvArgs: zapscript.NewAdvArgs(map[string]string{"platform": "win", "fullscreen": "yes", "lang": "en"}),
+			},
+			want: "**launch:game.exe?fullscreen=yes&lang=en&platform=win",
+		},
+		{
 			name: "advanced args only",
 			cmd: zapscript.Command{
 				Name:    "example",
@@ -109,8 +117,8 @@ func TestCommandString(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			got := tt.cmd.String()
-			if got != tt.want {
-				t.Errorf("Command.String() = %q, want %q", got, tt.want)
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("Command.String() mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}
@@ -160,9 +168,22 @@ func TestCommandString_RoundTrip(t *testing.T) {
 				t.Fatalf("expected 1 command from re-parse, got %d", len(script2.Cmds))
 			}
 
-			// Compare
-			if diff := cmp.Diff(script1.Cmds[0], script2.Cmds[0], cmpopts.IgnoreUnexported(zapscript.AdvArgs{})); diff != "" {
-				t.Errorf("round-trip mismatch (-original +reparsed):\n  input:    %s\n  string(): %s\n%s",
+			cmd1 := script1.Cmds[0]
+			cmd2 := script2.Cmds[0]
+
+			// Compare Name and Args
+			if diff := cmp.Diff(cmd1.Name, cmd2.Name); diff != "" {
+				t.Errorf("round-trip Name mismatch (-original +reparsed):\n  input: %s\n  string(): %s\n%s",
+					input, str, diff)
+			}
+			if diff := cmp.Diff(cmd1.Args, cmd2.Args); diff != "" {
+				t.Errorf("round-trip Args mismatch (-original +reparsed):\n  input: %s\n  string(): %s\n%s",
+					input, str, diff)
+			}
+
+			// Compare AdvArgs via public Raw() accessor
+			if diff := cmp.Diff(cmd1.AdvArgs.Raw(), cmd2.AdvArgs.Raw()); diff != "" {
+				t.Errorf("round-trip AdvArgs mismatch (-original +reparsed):\n  input: %s\n  string(): %s\n%s",
 					input, str, diff)
 			}
 		})

--- a/command_string_test.go
+++ b/command_string_test.go
@@ -111,6 +111,56 @@ func TestCommandString(t *testing.T) {
 			cmd:  zapscript.Command{Name: "input.gamepad", Args: []string{"^", "^", "V", "V", "<", ">"}},
 			want: "**input.gamepad:^^VV<>",
 		},
+		{
+			name: "arg with double quote",
+			cmd:  zapscript.Command{Name: "echo", Args: []string{`say "hi"`}},
+			want: `**echo:"say ^"hi^""`,
+		},
+		{
+			name: "arg with carriage return",
+			cmd:  zapscript.Command{Name: "echo", Args: []string{"line1\rline2"}},
+			want: `**echo:"line1^rline2"`,
+		},
+		{
+			name: "adv arg value with comma",
+			cmd: zapscript.Command{
+				Name:    "cmd",
+				AdvArgs: zapscript.NewAdvArgs(map[string]string{"list": "a,b,c"}),
+			},
+			want: `**cmd?list="a,b,c"`,
+		},
+		{
+			name: "adv arg value with colon",
+			cmd: zapscript.Command{
+				Name:    "cmd",
+				AdvArgs: zapscript.NewAdvArgs(map[string]string{"addr": "host:8080"}),
+			},
+			want: `**cmd?addr="host:8080"`,
+		},
+		{
+			name: "adv arg value with newline",
+			cmd: zapscript.Command{
+				Name:    "cmd",
+				AdvArgs: zapscript.NewAdvArgs(map[string]string{"msg": "hello\nworld"}),
+			},
+			want: `**cmd?msg="hello^nworld"`,
+		},
+		{
+			name: "adv arg value with tab",
+			cmd: zapscript.Command{
+				Name:    "cmd",
+				AdvArgs: zapscript.NewAdvArgs(map[string]string{"data": "col1\tcol2"}),
+			},
+			want: `**cmd?data="col1^tcol2"`,
+		},
+		{
+			name: "adv arg value with caret",
+			cmd: zapscript.Command{
+				Name:    "cmd",
+				AdvArgs: zapscript.NewAdvArgs(map[string]string{"expr": "2^3"}),
+			},
+			want: `**cmd?expr="2^^3"`,
+		},
 	}
 
 	for _, tt := range tests {
@@ -127,7 +177,7 @@ func TestCommandString(t *testing.T) {
 func TestCommandString_RoundTrip(t *testing.T) {
 	t.Parallel()
 
-	// Commands that should round-trip: parse → String() → parse → same Command
+	// Ensure parse → String() → parse preserves command semantics
 	inputs := []string{
 		"**stop",
 		"**launch:/games/snes/mario.sfc",
@@ -145,20 +195,18 @@ func TestCommandString_RoundTrip(t *testing.T) {
 		t.Run(input, func(t *testing.T) {
 			t.Parallel()
 
-			// Parse the original input
 			reader1 := zapscript.NewParser(input)
 			script1, err := reader1.ParseScript()
 			if err != nil {
 				t.Fatalf("first parse failed: %v", err)
 			}
+			// Each input is a single command
 			if len(script1.Cmds) != 1 {
 				t.Fatalf("expected 1 command, got %d", len(script1.Cmds))
 			}
 
-			// Convert to string
 			str := script1.Cmds[0].String()
 
-			// Parse the string output
 			reader2 := zapscript.NewParser(str)
 			script2, err := reader2.ParseScript()
 			if err != nil {
@@ -171,7 +219,6 @@ func TestCommandString_RoundTrip(t *testing.T) {
 			cmd1 := script1.Cmds[0]
 			cmd2 := script2.Cmds[0]
 
-			// Compare Name and Args
 			if diff := cmp.Diff(cmd1.Name, cmd2.Name); diff != "" {
 				t.Errorf("round-trip Name mismatch (-original +reparsed):\n  input: %s\n  string(): %s\n%s",
 					input, str, diff)
@@ -180,8 +227,6 @@ func TestCommandString_RoundTrip(t *testing.T) {
 				t.Errorf("round-trip Args mismatch (-original +reparsed):\n  input: %s\n  string(): %s\n%s",
 					input, str, diff)
 			}
-
-			// Compare AdvArgs via public Raw() accessor
 			if diff := cmp.Diff(cmd1.AdvArgs.Raw(), cmd2.AdvArgs.Raw()); diff != "" {
 				t.Errorf("round-trip AdvArgs mismatch (-original +reparsed):\n  input: %s\n  string(): %s\n%s",
 					input, str, diff)

--- a/reader.go
+++ b/reader.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"strings"
 	"unicode/utf8"
 )
 
@@ -92,6 +93,98 @@ type Command struct {
 	AdvArgs AdvArgs
 	Name    string
 	Args    []string
+}
+
+// argNeedsQuoting returns true if the arg contains characters that require
+// double-quoting to be safely represented in ZapScript.
+func argNeedsQuoting(s string) bool {
+	for _, ch := range s {
+		switch ch {
+		case SymArgSep, SymArgStart, SymAdvArgStart, SymAdvArgSep,
+			SymAdvArgEq, SymArgDoubleQuote, SymCmdSep, SymEscapeSeq,
+			'\n', '\r', '\t':
+			return true
+		}
+	}
+	return false
+}
+
+// escapeArg re-escapes control characters using ZapScript escape sequences
+// and wraps the arg in double quotes.
+func escapeArg(s string) string {
+	var b strings.Builder
+	b.WriteByte('"')
+	for _, ch := range s {
+		switch ch {
+		case '"':
+			b.WriteRune(SymEscapeSeq)
+			b.WriteByte('"')
+		case '\n':
+			b.WriteRune(SymEscapeSeq)
+			b.WriteByte('n')
+		case '\r':
+			b.WriteRune(SymEscapeSeq)
+			b.WriteByte('r')
+		case '\t':
+			b.WriteRune(SymEscapeSeq)
+			b.WriteByte('t')
+		case SymEscapeSeq:
+			b.WriteRune(SymEscapeSeq)
+			b.WriteRune(SymEscapeSeq)
+		default:
+			b.WriteRune(ch)
+		}
+	}
+	b.WriteByte('"')
+	return b.String()
+}
+
+// String returns the canonical ZapScript representation of the command.
+// The output is valid ZapScript that can be re-parsed to produce an
+// equivalent Command.
+func (c Command) String() string {
+	var b strings.Builder
+	b.WriteString("**")
+	b.WriteString(c.Name)
+
+	if len(c.Args) > 0 {
+		b.WriteRune(SymArgStart)
+
+		if isInputMacroCmd(c.Name) {
+			// Input macro commands concatenate args directly
+			for _, arg := range c.Args {
+				b.WriteString(arg)
+			}
+		} else {
+			for i, arg := range c.Args {
+				if i > 0 {
+					b.WriteRune(SymArgSep)
+				}
+				if argNeedsQuoting(arg) {
+					b.WriteString(escapeArg(arg))
+				} else {
+					b.WriteString(arg)
+				}
+			}
+		}
+	}
+
+	if !c.AdvArgs.IsEmpty() {
+		b.WriteRune(SymAdvArgStart)
+		first := true
+		c.AdvArgs.Range(func(key Key, value string) bool {
+			if !first {
+				b.WriteRune(SymAdvArgSep)
+			}
+			first = false
+			b.WriteString(string(key))
+			b.WriteRune(SymAdvArgEq)
+			b.WriteString(value)
+			return true
+		})
+	}
+
+	return b.String()
 }
 
 type Script struct {

--- a/reader.go
+++ b/reader.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"sort"
 	"strings"
 	"unicode/utf8"
 )
@@ -113,29 +114,29 @@ func argNeedsQuoting(s string) bool {
 // and wraps the arg in double quotes.
 func escapeArg(s string) string {
 	var b strings.Builder
-	b.WriteByte('"')
+	_, _ = b.WriteRune('"')
 	for _, ch := range s {
 		switch ch {
 		case '"':
-			b.WriteRune(SymEscapeSeq)
-			b.WriteByte('"')
+			_, _ = b.WriteRune(SymEscapeSeq)
+			_, _ = b.WriteRune('"')
 		case '\n':
-			b.WriteRune(SymEscapeSeq)
-			b.WriteByte('n')
+			_, _ = b.WriteRune(SymEscapeSeq)
+			_, _ = b.WriteRune('n')
 		case '\r':
-			b.WriteRune(SymEscapeSeq)
-			b.WriteByte('r')
+			_, _ = b.WriteRune(SymEscapeSeq)
+			_, _ = b.WriteRune('r')
 		case '\t':
-			b.WriteRune(SymEscapeSeq)
-			b.WriteByte('t')
+			_, _ = b.WriteRune(SymEscapeSeq)
+			_, _ = b.WriteRune('t')
 		case SymEscapeSeq:
-			b.WriteRune(SymEscapeSeq)
-			b.WriteRune(SymEscapeSeq)
+			_, _ = b.WriteRune(SymEscapeSeq)
+			_, _ = b.WriteRune(SymEscapeSeq)
 		default:
-			b.WriteRune(ch)
+			_, _ = b.WriteRune(ch)
 		}
 	}
-	b.WriteByte('"')
+	_, _ = b.WriteRune('"')
 	return b.String()
 }
 
@@ -144,44 +145,55 @@ func escapeArg(s string) string {
 // equivalent Command.
 func (c Command) String() string {
 	var b strings.Builder
-	b.WriteString("**")
-	b.WriteString(c.Name)
+	_, _ = b.WriteString("**")
+	_, _ = b.WriteString(c.Name)
 
 	if len(c.Args) > 0 {
-		b.WriteRune(SymArgStart)
+		_, _ = b.WriteRune(SymArgStart)
 
 		if isInputMacroCmd(c.Name) {
 			// Input macro commands concatenate args directly
 			for _, arg := range c.Args {
-				b.WriteString(arg)
+				_, _ = b.WriteString(arg)
 			}
 		} else {
 			for i, arg := range c.Args {
 				if i > 0 {
-					b.WriteRune(SymArgSep)
+					_, _ = b.WriteRune(SymArgSep)
 				}
 				if argNeedsQuoting(arg) {
-					b.WriteString(escapeArg(arg))
+					_, _ = b.WriteString(escapeArg(arg))
 				} else {
-					b.WriteString(arg)
+					_, _ = b.WriteString(arg)
 				}
 			}
 		}
 	}
 
 	if !c.AdvArgs.IsEmpty() {
-		b.WriteRune(SymAdvArgStart)
-		first := true
-		c.AdvArgs.Range(func(key Key, value string) bool {
-			if !first {
-				b.WriteRune(SymAdvArgSep)
-			}
-			first = false
-			b.WriteString(string(key))
-			b.WriteRune(SymAdvArgEq)
-			b.WriteString(value)
+		_, _ = b.WriteRune(SymAdvArgStart)
+
+		// Collect and sort keys for deterministic output
+		var keys []string
+		c.AdvArgs.Range(func(key Key, _ string) bool {
+			keys = append(keys, string(key))
 			return true
 		})
+		sort.Strings(keys)
+
+		for i, key := range keys {
+			if i > 0 {
+				_, _ = b.WriteRune(SymAdvArgSep)
+			}
+			_, _ = b.WriteString(key)
+			_, _ = b.WriteRune(SymAdvArgEq)
+			value := c.AdvArgs.Get(Key(key))
+			if argNeedsQuoting(value) {
+				_, _ = b.WriteString(escapeArg(value))
+			} else {
+				_, _ = b.WriteString(value)
+			}
+		}
 	}
 
 	return b.String()


### PR DESCRIPTION
## Summary
- Adds `Command.String()` that returns the canonical ZapScript representation
- Handles quoting only when args contain special characters (commas, colons, etc.)
- Re-escapes control characters (`\n` → `^n`, `\t` → `^t`, `^` → `^^`)
- Reconstructs input macro commands (`input.keyboard`, `input.gamepad`) in concatenated format
- Round-trip tested: parse → String() → parse produces equivalent Command

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive tests validating command text formatting and parse/string/parse round-trips to ensure consistent serialization across edge cases.

* **Chores**
  * Implemented canonical command serialization with deterministic ordering of advanced arguments and robust escaping/quoting for special characters and input-macro argument sequences.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->