### PR TITLE
fix: collapse consecutive dashes in NormalizeTag

### DIFF
--- a/tagfilter.go
+++ b/tagfilter.go
@@ -22,14 +22,16 @@ import (
 )
 
 var (
-	reColonSpacing = regexp.MustCompile(`\s*:\s*`)
-	reSpecialChars = regexp.MustCompile(`[^a-z0-9:,+\-]`)
+	reColonSpacing    = regexp.MustCompile(`\s*:\s*`)
+	reSpecialChars    = regexp.MustCompile(`[^a-z0-9:,+\-]`)
+	reConsecutiveDash = regexp.MustCompile(`-{2,}`)
 )
 
 // NormalizeTag normalizes a tag string for consistent matching.
 // Applied to BOTH type and value parts separately.
 // Rules: trim whitespace, normalize colon spacing, lowercase, spaces→dashes,
-// periods→dashes, and remove special chars (except colon, dash, and comma).
+// periods→dashes, remove special chars (except colon, dash, and comma),
+// and collapse consecutive dashes into one.
 func NormalizeTag(s string) string {
 	// 1. Trim whitespace
 	s = strings.TrimSpace(s)
@@ -49,6 +51,9 @@ func NormalizeTag(s string) string {
 	// 6. Remove other special chars (except colon, dash, and comma)
 	// Keep: a-z, 0-9, dash, colon, comma
 	s = reSpecialChars.ReplaceAllString(s, "")
+
+	// 7. Collapse consecutive dashes into one (e.g. "V. Gabriel" → "v--gabriel" → "v-gabriel")
+	s = reConsecutiveDash.ReplaceAllString(s, "-")
 
 	return s
 }

--- a/tagfilter_test.go
+++ b/tagfilter_test.go
@@ -64,6 +64,11 @@ func TestNormalizeTag(t *testing.T) {
 			input: "my-tag:value,other",
 			want:  "my-tag:value,other",
 		},
+		{
+			name:  "consecutive dashes collapsed",
+			input: "V. Gabriel",
+			want:  "v-gabriel",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

- `NormalizeTag` converts periods to dashes (step 5) and spaces to dashes (step 4), so an input like `"V. Gabriel"` produces `"v--gabriel"` (two consecutive dashes)
- Add a final step that collapses any run of two or more dashes into a single dash, so the result is `"v-gabriel"`

This was discovered during smoke testing of TOSEC filename parsing: publisher names with initials like `"V. Gabriel"` were producing `rev:1` instead of `publisher:v-gabriel` because `parseCommaSeparatedTags` split on `-` and matched the lone `"v"` token against the `rev:1` mapping.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tag normalization to collapse multiple consecutive dashes into a single dash for more consistent tag formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->