### PR TITLE
feat: add write command model

### DIFF
--- a/models.go
+++ b/models.go
@@ -37,6 +37,7 @@ const (
 	ZapScriptCmdExecute    = "execute"
 	ZapScriptCmdDelay      = "delay"
 	ZapScriptCmdEvaluate   = "evaluate"
+	ZapScriptCmdWrite      = "write"
 	ZapScriptCmdStop       = "stop"
 	ZapScriptCmdEcho       = "echo"
 	ZapScriptCmdControl    = "control"
@@ -97,6 +98,10 @@ type CmdLaunchArgs struct {
 	URL       *string `json:"url"`
 	PreNotice *string `json:"preNotice"`
 	Path      string  `json:"path" arg:"position=1"`
+}
+
+type CmdWriteArgs struct {
+	Payload string `json:"payload" arg:"position=1"`
 }
 
 type CmdNotice struct {

--- a/parser_test.go
+++ b/parser_test.go
@@ -61,6 +61,18 @@ func TestParse(t *testing.T) {
 			},
 		},
 		{
+			name:  "write command",
+			input: `**write:'**launch:/games/snes/zelda.sfc||**echo:written'`,
+			want: zapscript.Script{
+				Cmds: []zapscript.Command{
+					{
+						Name: zapscript.ZapScriptCmdWrite,
+						Args: []string{"**launch:/games/snes/zelda.sfc||**echo:written"},
+					},
+				},
+			},
+		},
+		{
 			name:  "two commands separated",
 			input: `**first:1,2||**second:3,4`,
 			want: zapscript.Script{


### PR DESCRIPTION
## Summary
- add official `write` ZapScript command constant
- add `CmdWriteArgs` model with payload positional argument
- cover parsing quoted write payloads

## Validation
- go test ./...
- task lint-fix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced the "write" command to ZapScript, enabling users to execute write operations with customizable payloads in their automation workflows.

* **Tests**
  * Added comprehensive parser test coverage for the new "write" command, including validation of payload arguments and command formatting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ZaparooProject/go-zapscript/pull/24?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->