### PR TITLE
feat: add launch set name arguments

### DIFF
--- a/types.go
+++ b/types.go
@@ -38,15 +38,17 @@ type Key string
 
 // Argument key constants for advarg struct tags and map lookups.
 const (
-	KeyWhen      Key = "when"
-	KeyLauncher  Key = "launcher"
-	KeySystem    Key = "system"
-	KeyAction    Key = "action"
-	KeyTags      Key = "tags"
-	KeyMode      Key = "mode"
-	KeyName      Key = "name"
-	KeyPreNotice Key = "pre_notice"
-	KeyHidden    Key = "hidden"
+	KeyWhen           Key = "when"
+	KeyLauncher       Key = "launcher"
+	KeySystem         Key = "system"
+	KeyAction         Key = "action"
+	KeySetName        Key = "set_name"
+	KeySetNameSameDir Key = "set_name_same_dir"
+	KeyTags           Key = "tags"
+	KeyMode           Key = "mode"
+	KeyName           Key = "name"
+	KeyPreNotice      Key = "pre_notice"
+	KeyHidden         Key = "hidden"
 )
 
 // Action values for the action advanced argument.
@@ -69,9 +71,18 @@ type GlobalArgs struct {
 	When string `advarg:"when"`
 }
 
+// LaunchSetNameArgs contains optional launcher set-name advanced arguments.
+type LaunchSetNameArgs struct {
+	// SetName specifies a platform-defined launch profile/core name override.
+	SetName string `advarg:"set_name"`
+	// SetNameSameDir controls whether SetName should keep the original game directory.
+	SetNameSameDir string `advarg:"set_name_same_dir"`
+}
+
 // LaunchArgs contains advanced arguments for the launch command.
 type LaunchArgs struct {
 	GlobalArgs
+	LaunchSetNameArgs
 	// Launcher overrides the default launcher by ID.
 	Launcher string `advarg:"launcher" validate:"omitempty,launcher"` //nolint:revive // custom validator
 	// System specifies the target system for path resolution.
@@ -87,6 +98,7 @@ type LaunchArgs struct {
 // LaunchRandomArgs contains advanced arguments for the launch.random command.
 type LaunchRandomArgs struct {
 	GlobalArgs
+	LaunchSetNameArgs
 	// Launcher overrides the default launcher by ID.
 	Launcher string `advarg:"launcher" validate:"omitempty,launcher"` //nolint:revive // custom validator
 	// Action specifies the launch action (run, details).
@@ -98,6 +110,7 @@ type LaunchRandomArgs struct {
 // LaunchSearchArgs contains advanced arguments for the launch.search command.
 type LaunchSearchArgs struct {
 	GlobalArgs
+	LaunchSetNameArgs
 	// Launcher overrides the default launcher by ID.
 	Launcher string `advarg:"launcher" validate:"omitempty,launcher"` //nolint:revive // custom validator
 	// Action specifies the launch action (run, details).
@@ -109,6 +122,7 @@ type LaunchSearchArgs struct {
 // LaunchTitleArgs contains advanced arguments for the launch.title command.
 type LaunchTitleArgs struct {
 	GlobalArgs
+	LaunchSetNameArgs
 	// Launcher overrides the default launcher by ID.
 	Launcher string `advarg:"launcher" validate:"omitempty,launcher"` //nolint:revive // custom validator
 	// Action specifies the launch action (run, details).
@@ -120,6 +134,7 @@ type LaunchTitleArgs struct {
 // LaunchLastArgs contains advanced arguments for the launch.last command.
 type LaunchLastArgs struct {
 	GlobalArgs
+	LaunchSetNameArgs
 	// Launcher overrides the default launcher by ID.
 	Launcher string `advarg:"launcher" validate:"omitempty,launcher"` //nolint:revive // custom validator
 	// Action specifies the launch action (run, details).

--- a/types_test.go
+++ b/types_test.go
@@ -1,0 +1,47 @@
+// Copyright 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package zapscript
+
+import "testing"
+
+func TestLaunchArgsSetNameFields(t *testing.T) {
+	t.Parallel()
+
+	args := LaunchArgs{
+		LaunchSetNameArgs: LaunchSetNameArgs{
+			SetName:        "RA_NES",
+			SetNameSameDir: "1",
+		},
+	}
+
+	if args.SetName != "RA_NES" {
+		t.Fatalf("SetName = %q, want %q", args.SetName, "RA_NES")
+	}
+	if args.SetNameSameDir != "1" {
+		t.Fatalf("SetNameSameDir = %q, want %q", args.SetNameSameDir, "1")
+	}
+}
+
+func TestLaunchSetNameKeys(t *testing.T) {
+	t.Parallel()
+
+	if KeySetName != "set_name" {
+		t.Fatalf("KeySetName = %q, want %q", KeySetName, "set_name")
+	}
+	if KeySetNameSameDir != "set_name_same_dir" {
+		t.Fatalf("KeySetNameSameDir = %q, want %q", KeySetNameSameDir, "set_name_same_dir")
+	}
+}


### PR DESCRIPTION
## Summary
- add set_name and set_name_same_dir advanced argument keys
- add shared launch set-name args embedded in launch command arg structs
- cover new keys and fields with tests

## Test
- go test ./...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for advanced naming options (`set_name` and `set_name_same_dir`) across multiple launch operations, enabling more flexible configuration of item naming behavior.

* **Tests**
  * Added comprehensive test coverage for new naming configuration options and their associated constants.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ZaparooProject/go-zapscript/pull/28?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->