### PR TITLE
fix: expose launch set name args directly

### DIFF
--- a/types.go
+++ b/types.go
@@ -71,18 +71,13 @@ type GlobalArgs struct {
 	When string `advarg:"when"`
 }
 
-// LaunchSetNameArgs contains optional launcher set-name advanced arguments.
-type LaunchSetNameArgs struct {
+// LaunchArgs contains advanced arguments for the launch command.
+type LaunchArgs struct {
+	GlobalArgs
 	// SetName specifies a platform-defined launch profile/core name override.
 	SetName string `advarg:"set_name"`
 	// SetNameSameDir controls whether SetName should keep the original game directory.
 	SetNameSameDir string `advarg:"set_name_same_dir"`
-}
-
-// LaunchArgs contains advanced arguments for the launch command.
-type LaunchArgs struct {
-	GlobalArgs
-	LaunchSetNameArgs
 	// Launcher overrides the default launcher by ID.
 	Launcher string `advarg:"launcher" validate:"omitempty,launcher"` //nolint:revive // custom validator
 	// System specifies the target system for path resolution.
@@ -98,7 +93,10 @@ type LaunchArgs struct {
 // LaunchRandomArgs contains advanced arguments for the launch.random command.
 type LaunchRandomArgs struct {
 	GlobalArgs
-	LaunchSetNameArgs
+	// SetName specifies a platform-defined launch profile/core name override.
+	SetName string `advarg:"set_name"`
+	// SetNameSameDir controls whether SetName should keep the original game directory.
+	SetNameSameDir string `advarg:"set_name_same_dir"`
 	// Launcher overrides the default launcher by ID.
 	Launcher string `advarg:"launcher" validate:"omitempty,launcher"` //nolint:revive // custom validator
 	// Action specifies the launch action (run, details).
@@ -110,7 +108,10 @@ type LaunchRandomArgs struct {
 // LaunchSearchArgs contains advanced arguments for the launch.search command.
 type LaunchSearchArgs struct {
 	GlobalArgs
-	LaunchSetNameArgs
+	// SetName specifies a platform-defined launch profile/core name override.
+	SetName string `advarg:"set_name"`
+	// SetNameSameDir controls whether SetName should keep the original game directory.
+	SetNameSameDir string `advarg:"set_name_same_dir"`
 	// Launcher overrides the default launcher by ID.
 	Launcher string `advarg:"launcher" validate:"omitempty,launcher"` //nolint:revive // custom validator
 	// Action specifies the launch action (run, details).
@@ -122,7 +123,10 @@ type LaunchSearchArgs struct {
 // LaunchTitleArgs contains advanced arguments for the launch.title command.
 type LaunchTitleArgs struct {
 	GlobalArgs
-	LaunchSetNameArgs
+	// SetName specifies a platform-defined launch profile/core name override.
+	SetName string `advarg:"set_name"`
+	// SetNameSameDir controls whether SetName should keep the original game directory.
+	SetNameSameDir string `advarg:"set_name_same_dir"`
 	// Launcher overrides the default launcher by ID.
 	Launcher string `advarg:"launcher" validate:"omitempty,launcher"` //nolint:revive // custom validator
 	// Action specifies the launch action (run, details).
@@ -134,7 +138,10 @@ type LaunchTitleArgs struct {
 // LaunchLastArgs contains advanced arguments for the launch.last command.
 type LaunchLastArgs struct {
 	GlobalArgs
-	LaunchSetNameArgs
+	// SetName specifies a platform-defined launch profile/core name override.
+	SetName string `advarg:"set_name"`
+	// SetNameSameDir controls whether SetName should keep the original game directory.
+	SetNameSameDir string `advarg:"set_name_same_dir"`
 	// Launcher overrides the default launcher by ID.
 	Launcher string `advarg:"launcher" validate:"omitempty,launcher"` //nolint:revive // custom validator
 	// Action specifies the launch action (run, details).

--- a/types_advargs_test.go
+++ b/types_advargs_test.go
@@ -1,0 +1,48 @@
+// Copyright 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package zapscript
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestLaunchArgsSetNameAdvargFields(t *testing.T) {
+	t.Parallel()
+
+	requireAdvargField(t, reflect.TypeOf(LaunchArgs{}), "set_name")
+	requireAdvargField(t, reflect.TypeOf(LaunchArgs{}), "set_name_same_dir")
+	requireAdvargField(t, reflect.TypeOf(LaunchRandomArgs{}), "set_name")
+	requireAdvargField(t, reflect.TypeOf(LaunchRandomArgs{}), "set_name_same_dir")
+	requireAdvargField(t, reflect.TypeOf(LaunchSearchArgs{}), "set_name")
+	requireAdvargField(t, reflect.TypeOf(LaunchSearchArgs{}), "set_name_same_dir")
+	requireAdvargField(t, reflect.TypeOf(LaunchTitleArgs{}), "set_name")
+	requireAdvargField(t, reflect.TypeOf(LaunchTitleArgs{}), "set_name_same_dir")
+	requireAdvargField(t, reflect.TypeOf(LaunchLastArgs{}), "set_name")
+	requireAdvargField(t, reflect.TypeOf(LaunchLastArgs{}), "set_name_same_dir")
+}
+
+func requireAdvargField(t *testing.T, typ reflect.Type, tag string) {
+	t.Helper()
+
+	for i := range typ.NumField() {
+		field := typ.Field(i)
+		if field.Tag.Get("advarg") == tag {
+			return
+		}
+	}
+	t.Fatalf("%s missing advarg field %q", typ.Name(), tag)
+}

--- a/types_test.go
+++ b/types_test.go
@@ -21,10 +21,8 @@ func TestLaunchArgsSetNameFields(t *testing.T) {
 	t.Parallel()
 
 	args := LaunchArgs{
-		LaunchSetNameArgs: LaunchSetNameArgs{
-			SetName:        "RA_NES",
-			SetNameSameDir: "1",
-		},
+		SetName:        "RA_NES",
+		SetNameSameDir: "1",
 	}
 
 	if args.SetName != "RA_NES" {


### PR DESCRIPTION
## Summary
- move set_name and set_name_same_dir onto each launch arg struct directly
- keep key constants from v0.9.0
- add reflection coverage that launch arg structs expose the advarg tags

## Test
- go test ./...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized internal argument structure to improve code maintainability and reduce duplication.

* **Tests**
  * Updated test suite to reflect code restructuring.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ZaparooProject/go-zapscript/pull/29?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->