### PR TITLE
work needed for adding coin 3 and coin 4 inputs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -235,7 +235,7 @@ result, err := parser.EvalExpressions(envStruct)
 - **System**: `execute`, `delay`, `evaluate`, `stop`, `echo`
 - **MiSTer**: `mister.ini`, `mister.core`, `mister.script`, `mister.mgl`
 - **HTTP**: `http.get`, `http.post`
-- **Input**: `input.keyboard`, `input.gamepad`, `input.coinp1`, `input.coinp2`
+- **Input**: `input.keyboard`, `input.gamepad`, `input.coinp1`, `input.coinp2`, `input.coinp3`, `input.coinp4`
 - **UI**: `ui.notice`, `ui.picker`
 - **Metadata**: `traits` (parsed from `#key=value` syntax)
 

--- a/models.go
+++ b/models.go
@@ -56,6 +56,8 @@ const (
 	ZapScriptCmdInputGamepad  = "input.gamepad"
 	ZapScriptCmdInputCoinP1   = "input.coinp1"
 	ZapScriptCmdInputCoinP2   = "input.coinp2"
+	ZapScriptCmdInputCoinP3   = "input.coinp3"
+	ZapScriptCmdInputCoinP4   = "input.coinp4"
 
 	ZapScriptCmdUINotice = "ui.notice"
 	ZapScriptCmdUIPicker = "ui.picker"


### PR DESCRIPTION
other part of https://github.com/ZaparooProject/zaparoo-core/pull/859

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for coin input types 3 and 4. This expands the coin input capabilities to support a total of four coin-operated input devices, complementing the existing keyboard and gamepad input options available.

* **Documentation**
  * Updated the supported commands list to reflect the newly available coin input types.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ZaparooProject/go-zapscript/pull/31?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->