### PR TITLE
feat: add slot advanced arguments

### DIFF
--- a/types.go
+++ b/types.go
@@ -44,6 +44,7 @@ const (
 	KeyAction         Key = "action"
 	KeySetName        Key = "set_name"
 	KeySetNameSameDir Key = "set_name_same_dir"
+	KeySlot           Key = "slot"
 	KeyTags           Key = "tags"
 	KeyMode           Key = "mode"
 	KeyName           Key = "name"
@@ -84,6 +85,8 @@ type LaunchArgs struct {
 	System string `advarg:"system" validate:"omitempty,system"` //nolint:revive // custom validator
 	// Action specifies the launch action (run, details).
 	Action string `advarg:"action" validate:"omitempty,oneof=run details"`
+	// Slot selects the media slot for launch routing.
+	Slot string `advarg:"slot"`
 	// Name is the filename for remote file installation.
 	Name string `advarg:"name"`
 	// PreNotice is shown before remote file download.
@@ -101,6 +104,8 @@ type LaunchRandomArgs struct {
 	Launcher string `advarg:"launcher" validate:"omitempty,launcher"` //nolint:revive // custom validator
 	// Action specifies the launch action (run, details).
 	Action string `advarg:"action" validate:"omitempty,oneof=run details"`
+	// Slot selects the media slot for launch routing.
+	Slot string `advarg:"slot"`
 	// Tags filters results by tag criteria.
 	Tags []TagFilter `advarg:"tags"`
 }
@@ -116,6 +121,8 @@ type LaunchSearchArgs struct {
 	Launcher string `advarg:"launcher" validate:"omitempty,launcher"` //nolint:revive // custom validator
 	// Action specifies the launch action (run, details).
 	Action string `advarg:"action" validate:"omitempty,oneof=run details"`
+	// Slot selects the media slot for launch routing.
+	Slot string `advarg:"slot"`
 	// Tags filters results by tag criteria.
 	Tags []TagFilter `advarg:"tags"`
 }
@@ -131,6 +138,8 @@ type LaunchTitleArgs struct {
 	Launcher string `advarg:"launcher" validate:"omitempty,launcher"` //nolint:revive // custom validator
 	// Action specifies the launch action (run, details).
 	Action string `advarg:"action" validate:"omitempty,oneof=run details"`
+	// Slot selects the media slot for launch routing.
+	Slot string `advarg:"slot"`
 	// Tags filters results by tag criteria.
 	Tags []TagFilter `advarg:"tags"`
 }
@@ -146,6 +155,8 @@ type LaunchLastArgs struct {
 	Launcher string `advarg:"launcher" validate:"omitempty,launcher"` //nolint:revive // custom validator
 	// Action specifies the launch action (run, details).
 	Action string `advarg:"action" validate:"omitempty,oneof=run details"`
+	// Slot selects the media slot for launch routing.
+	Slot string `advarg:"slot"`
 }
 
 // PlaylistArgs contains advanced arguments for playlist commands.
@@ -153,6 +164,8 @@ type PlaylistArgs struct {
 	GlobalArgs
 	// Mode controls playlist behavior (e.g., "shuffle").
 	Mode string `advarg:"mode" validate:"omitempty,oneof=shuffle"`
+	// Slot selects the media slot for playlist routing.
+	Slot string `advarg:"slot"`
 }
 
 // MisterScriptArgs contains advanced arguments for MiSTer script commands.

--- a/types_advargs_test.go
+++ b/types_advargs_test.go
@@ -35,6 +35,17 @@ func TestLaunchArgsSetNameAdvargFields(t *testing.T) {
 	requireAdvargField(t, reflect.TypeOf(LaunchLastArgs{}), "set_name_same_dir")
 }
 
+func TestSlotAdvargFields(t *testing.T) {
+	t.Parallel()
+
+	requireAdvargField(t, reflect.TypeOf(LaunchArgs{}), "slot")
+	requireAdvargField(t, reflect.TypeOf(LaunchRandomArgs{}), "slot")
+	requireAdvargField(t, reflect.TypeOf(LaunchSearchArgs{}), "slot")
+	requireAdvargField(t, reflect.TypeOf(LaunchTitleArgs{}), "slot")
+	requireAdvargField(t, reflect.TypeOf(LaunchLastArgs{}), "slot")
+	requireAdvargField(t, reflect.TypeOf(PlaylistArgs{}), "slot")
+}
+
 func requireAdvargField(t *testing.T, typ reflect.Type, tag string) {
 	t.Helper()
 

--- a/types_test.go
+++ b/types_test.go
@@ -43,3 +43,11 @@ func TestLaunchSetNameKeys(t *testing.T) {
 		t.Fatalf("KeySetNameSameDir = %q, want %q", KeySetNameSameDir, "set_name_same_dir")
 	}
 }
+
+func TestSlotKey(t *testing.T) {
+	t.Parallel()
+
+	if KeySlot != "slot" {
+		t.Fatalf("KeySlot = %q, want %q", KeySlot, "slot")
+	}
+}


### PR DESCRIPTION
## Summary
- add a typed `slot` advanced argument key
- expose `slot` on launch and playlist argument structs
- cover slot advarg tags and key constant in tests

## Validation
- go test ./...
- task lint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for a `slot` argument in advanced arguments, enabling users to specify slot parameters when launching content and managing playlists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->