### PR TITLE
feat!: rename profile.switch command to profile

### DIFF
--- a/models.go
+++ b/models.go
@@ -65,8 +65,8 @@ const (
 
 	ZapScriptCmdTraits = "traits"
 
-	ZapScriptCmdProfileSwitch = "profile.switch"
-	ZapScriptCmdProfileClear  = "profile.clear"
+	ZapScriptCmdProfile      = "profile"
+	ZapScriptCmdProfileClear = "profile.clear"
 
 	ZapScriptCmdInputKey = "input.key" // DEPRECATED
 	ZapScriptCmdKey      = "key"       // DEPRECATED


### PR DESCRIPTION
Renames the ZapScript profile-switch command from `**profile.switch` to `**profile`, and the exported constant `ZapScriptCmdProfileSwitch` to `ZapScriptCmdProfile`. `profile.clear` is unchanged.

The profiles feature is unreleased in zaparoo-core (PR ZaparooProject/zaparoo-core#950), so no cards or consumers use the old command name yet — no alias or deprecation path is included.

BREAKING CHANGE: `ZapScriptCmdProfileSwitch` no longer exists; use `ZapScriptCmdProfile`. zaparoo-core's device-profiles branch has been updated to match and currently builds against this via a temporary `replace` directive, pending a tagged release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Updated profile command naming for improved consistency.
  * Replaced the profile-switch command with the standardized profile command.
  * Kept the profile-clear command unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->